### PR TITLE
fixed typos in scholarships page

### DIFF
--- a/diversity-scholarships/index.html
+++ b/diversity-scholarships/index.html
@@ -185,10 +185,10 @@ title: Apply for a Diversity Scholarship
             <a href="http://libraries.mit.edu/">The MIT Libraries</a>: Two Scholarships
         </h4>
         <h4>
-            <a href="http://esilibrary.com/">Equinox Software</a>: One Scholarships
+            <a href="http://esilibrary.com/">Equinox Software</a>: One Scholarship
         </h4>
         <h4>
-            <a href="http://www.library.northwestern.edu/">Northwestern University</a>: One Scholarships
+            <a href="http://www.library.northwestern.edu/">Northwestern University</a>: One Scholarship
         </h4>
         <h4>
             <a href="http://library.miami.edu/">University of Miami Libraries</a>: One scholarship


### PR DESCRIPTION
Note the typo in the branch name. womp!