### PR TITLE
turn on registration for first round

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -2,7 +2,7 @@ keynote-voting-link: "https://vote.code4lib.org/election/41"
 livestream-url: "https://www.youtube.com/user/code4lib"
 panel-proposal-form: "https://goo.gl/forms/q2KbVcO4ntkh6bPp1"
 panel-voting-link: "http://vote.code4lib.org/election/43"
-registration-form: ""
+registration-form: "https://www.eventsforce.net/concentra/14/register"
 shirt-proposal-form: "http://wiki.code4lib.org/2017_Code4Lib_T-Shirt_Design_Competition"
 shirt-voting-link: ""
 talk-proposal-form: "https://goo.gl/forms/GbM0jmSdXFkRdHAr2"
@@ -18,7 +18,7 @@ toggles:
   prop-shop: false
   prop-talk: false
   register-shop: false
-  register: false
+  register: true
   search: false
   vote-key: false
   vote-panels: false


### PR DESCRIPTION
Closes #99 

Note that CONCENTRA will, when the time comes, make the link
public (and not require an entry code), but please don't merge until before 12 p.m. EST on 12/14 (and maybe check with @kathy.azevedo in the C4L17 check) to coordinate timing.