### PR TITLE
wrap colon in quotes for YAML

### DIFF
--- a/_posts/2017-03-06-How-Do-We-Keep-Voting-Sustaining-Open-Source-Tools-in-a-CommunityDriven-Environment-Diebold-o-tron-Case-Study.html
+++ b/_posts/2017-03-06-How-Do-We-Keep-Voting-Sustaining-Open-Source-Tools-in-a-CommunityDriven-Environment-Diebold-o-tron-Case-Study.html
@@ -10,7 +10,7 @@ categories: workshops
 time: PM
 location: TBD
 slugTitle: how-do-we-keep-voting-sustaining-open-source-tools-in-a-community-driven-environment-diebold-o-tron-case-study
-title: How Do We Keep Voting?&#58; Sustaining Open Source Tools in a Community-Driven Environment: Diebold-o-tron Case Study
+title: "How Do We Keep Voting?&#58; Sustaining Open Source Tools in a Community-Driven Environment: Diebold-o-tron Case Study"
 ---
 <p>This session will take these concerns and focus the case study of diebold-o-tron, Code4Lib’s trusty voting software, currently maintained and deployed annually through the generosity of individuals.  Applying strategies for sustaining software in an Open Source community discussed in the related morning session, we will, as a group, develop a pilot strategy for treating conference voting as a service maintained by the Code4Lib community rather than a piece of software maintained by an individual.  
 


### PR DESCRIPTION
fixes a jekyll build error I was seeing:

> Error: could not read file /Users/phette23/code/2017.code4lib.org/_posts/2017-03-06-How-Do-We-Keep-Voting-Sustaining-Open-Source-Tools-in-a-CommunityDriven-Environment-Diebold-o-tron-Case-Study.html: (<unknown>): mapping values are not allowed in this context at line 13 column 98

The character referred to is a colon in the title of a workshop session, the string just needs to be wrapped in quotes so it's valid YAML.