### PR TITLE
turn on registration again

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -18,7 +18,7 @@ toggles:
   prop-shop: false
   prop-talk: false
   register-shop: false
-  register: false
+  register: true
   search: false
   vote-key: false
   vote-panels: false

--- a/attend/index.html
+++ b/attend/index.html
@@ -33,7 +33,7 @@ title: Attend
                 </ul>
                 <p>Pre-Conference Sessions are being offered on Monday, March 6, with an additional cost of $60 for the day.  If you are interested in attending, please add one or more optional sessions listed below to your schedule.</p>
                 <p>Please Note: Pre-Conference day is $60 regardless of the number of sessions you choose.  If you select two half-day sessions you will notice two charges of $60 per session and a Multi-Session Discount of $60, for a total daily charge of $60.</p>
-                <p>Pre-Conference Only registrations will happen at a later, TBD date.</p>
+                <p>Pre-Conference Only registrations are now available starting 11 January 2017.</p>
             </div>
         </div>
 


### PR DESCRIPTION
Closes #128. This should be merged just before 9 a.m. PST / 12 p.m. EST on 11 January; can check with CONCENTRA staff to verify when they've opened up their form.