### PR TITLE
poster presenter update

### DIFF
--- a/_data/speakers_final.yml
+++ b/_data/speakers_final.yml
@@ -90,10 +90,10 @@ elvia-arroyo-ramirez:
   Bio: |
     Elvia is the Processing Archivist for Latin American Collections at Princeton University. She holds a MLIS from the University of Pittsburgh and a BA in Art History from UCLA. Her professional interests are digital archives, digital preservation, and inclusive community building.
 
-anoj-atapattu:
-  Name: Anoj Atapattu
-  Last: Atapattu
-  Email: anoj@ksu.edu
+jeff-sheldon:
+  Name: Jeff Sheldon
+  Last: Sheldon
+  Email: jeffsheldon@gmail.com
   Show: 1
   Image-URL: /assets/img/speakers/nopic5.jpg
 

--- a/_posts/2017-03-06-Stacks-Guide-20-The-Dynamic-Physical-Finding-Aid.html
+++ b/_posts/2017-03-06-Stacks-Guide-20-The-Dynamic-Physical-Finding-Aid.html
@@ -1,9 +1,9 @@
 ---
 layout: presentation
-speakers-text: Jason Bengtson and Anoj Atapattu
+speakers-text: Jason Bengtson and Jeff Sheldon
 speakers: 
 - jason-bengtson
-- anoj-atapattu
+- jeff-sheldon
 day: 1
 group: 7
 type: poster


### PR DESCRIPTION
Updated 2nd presenter for poster "Stacks Guide 2.0" at request of 1st presenter (Jason Bengston).

Request from email:

>  ... due to a last-minute registration change, my co-presenter on the Stacksguide 2.0 poster wasn't Anoj Atapattu, but Jeff Sheldon. It would be very helpful for Jeff's professional development if you folks could change Anoj's name to Jeff's on the program ...